### PR TITLE
Fix command registration and prompt loading

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const { Client, Collection, GatewayIntentBits, REST, Routes } = require('discord.js');
-const inquirer = require('inquirer');
+const inquirer = require('inquirer').default;
 const yargs = require('yargs/yargs');
 const { hideBin } = require('yargs/helpers');
 
@@ -31,8 +31,16 @@ async function loadModules(modulesFolder, enabled = [], disabled = []) {
 
 async function registerCommands(client, commands) {
   const rest = new REST({ version: '10' }).setToken(client.token);
-  const data = commands.map(cmd => cmd.data.toJSON());
-  await rest.put(Routes.applicationCommands(client.user.id), { body: data });
+  const existing = await rest.get(Routes.applicationCommands(client.user.id));
+  for (const cmd of commands) {
+    const json = cmd.data.toJSON();
+    const current = existing.find(c => c.name === json.name && c.type === json.type);
+    if (current) {
+      await rest.patch(Routes.applicationCommand(client.user.id, current.id), { body: json });
+    } else {
+      await rest.post(Routes.applicationCommands(client.user.id), { body: json });
+    }
+  }
 }
 
 async function startBot(botName, config, tokens) {
@@ -53,7 +61,7 @@ async function startBot(botName, config, tokens) {
   const modules = await loadModules(modulesFolder, botConfig.enabled_modules, botConfig.disabled_modules);
   modules.forEach(m => client.commands.set(m.data.name, m));
 
-  client.once('ready', async () => {
+  client.once('clientReady', async () => {
     await registerCommands(client, modules);
     console.log(`${client.user.tag} ready`);
   });

--- a/modules/anon.js
+++ b/modules/anon.js
@@ -1,0 +1,69 @@
+const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
+
+const ANON_CHANNEL_IDS = [
+  '1314503562960834571', // Channel ID 1
+  '1314517087414124545'  // Channel ID 2
+];
+
+function isValidUrl(url) {
+  try {
+    new URL(url);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('anon')
+    .setDescription('Send an anonymous message, file, or link to specified channels.')
+    .addStringOption(option =>
+      option.setName('message')
+        .setDescription('Message or URL to send')
+        .setRequired(false)
+    )
+    .addAttachmentOption(option =>
+      option.setName('file')
+        .setDescription('File or image to send')
+        .setRequired(false)
+    ),
+  async execute(interaction) {
+    const message = interaction.options.getString('message');
+    const file = interaction.options.getAttachment('file');
+    const randomId = Math.floor(Math.random() * 9999) + 1;
+
+    const embed = new EmbedBuilder().setDescription(`### 🔏 [ANON-${randomId}] 🔏`);
+    const files = [];
+
+    if (file) {
+      if (file.contentType && file.contentType.startsWith('image')) {
+        embed.addFields({ name: '📬', value: `(${file.url})`, inline: false });
+        embed.setImage(file.url);
+      } else {
+        files.push({ attachment: file.url, name: file.name });
+        embed.addFields({ name: '📦', value: `[${file.name}](${file.url})`, inline: false });
+      }
+    }
+
+    if (message) {
+      if (isValidUrl(message)) {
+        embed.addFields({ name: '📷', value: message, inline: false });
+      } else {
+        embed.addFields({ name: '💬', value: message, inline: false });
+      }
+    }
+
+    if (embed.data.fields && embed.data.fields.length) {
+      for (const channelId of ANON_CHANNEL_IDS) {
+        const channel = interaction.client.channels.cache.get(channelId);
+        if (channel) {
+          await channel.send({ embeds: [embed], files });
+        }
+      }
+      await interaction.reply({ content: 'Sent anonymously!', ephemeral: true });
+    } else {
+      await interaction.reply({ content: 'You must provide a message or attach a file/image to send.', ephemeral: true });
+    }
+  }
+};


### PR DESCRIPTION
## Summary
- load inquirer default export to restore interactive prompts
- register commands individually to preserve app entry point
- use `clientReady` event name for Discord.js
- port anonymous message command from Python to Node as slash command

## Testing
- `node main.js --bot "bot 1"` *(fails: Token for bot 1 not found)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c0697acf08832d8b0491e2c5fd6de2